### PR TITLE
feat:给当前app依赖的非Manifest指定模块名添加app name作为命名空间

### DIFF
--- a/react-native/packager/react-packager/src/Bundler/index.js
+++ b/react-native/packager/react-packager/src/Bundler/index.js
@@ -211,6 +211,9 @@ class Bundler {
       polyfillModuleNames: opts.polyfillModuleNames,
       projectRoots: opts.projectRoots,
       resetCache: opts.resetCache,
+      // @Denis 传入extenalModules 和  manifestReferrence #8
+      extenalModules: this._extenalModules || {},
+      manifestReferrence: opts.manifestReferrence,
       transformCode:
         (module, code, transformCodeOptions) => this._transformer.transformFile(
           module.path,

--- a/react-native/packager/react-packager/src/Resolver/index.js
+++ b/react-native/packager/react-packager/src/Resolver/index.js
@@ -15,6 +15,10 @@ const declareOpts = require('../lib/declareOpts');
 const defaults = require('../../../defaults');
 const pathJoin = require('path').join;
 
+// @Denis
+const cwd = process.cwd();
+const appName = require(`${cwd}/package.json`).name;
+
 const validateOpts = declareOpts({
   projectRoots: {
     type: 'array',
@@ -63,6 +67,17 @@ const validateOpts = declareOpts({
   resetCache: {
     type: 'boolean',
     default: false,
+  },
+  // @Denis extenalModules
+  extenalModules: {
+    type: 'object',
+    required: false,
+    default: {},
+  },
+  // @Denis manifestReferrence
+  manifestReferrence: {
+    type: 'object',
+    required: false,
   },
 });
 
@@ -114,7 +129,9 @@ class Resolver {
         resetCache: options.resetCache,
       },
     });
-
+    // @Denis Bundler传入extenalModules 和 manifestReferrence #8
+    this._extenalModules = opts.extenalModules;
+    this._manifestReferrence = opts.manifestReferrence;
     this._minifyCode = opts.minifyCode;
     this._polyfillModuleNames = opts.polyfillModuleNames || [];
 
@@ -207,12 +224,29 @@ class Resolver {
     //    require('./c') => require(3);
     // -- in b/index.js:
     //    require('../a/c') => require(3);
-    const replaceModuleId = (codeMatch, quote, depName) =>
-      depName in resolvedDeps
+    // const replaceModuleId = (codeMatch, quote, depName) =>
+    //   depName in resolvedDeps
+    //     // @Denis
+    //     // ? `${JSON.stringify(resolvedDeps[depName])} /* ${depName} */`
+    //     ? `'${resolvedDeps[depName]}'`
+    //     : codeMatch;
+    // @Denis issue #8
+    const replaceModuleId = (codeMatch, quote, depName) => {
+      const resolvedDep = resolvedDeps[depName];
+
+      if (resolvedDep) {
+        const pkgName = resolvedDep.split('/')[0];
+        // 如果有传入manifest.json 并且模块不属于manifest内定义的，并且模块不属于当前App，需要给模块追加命名空间
+        return (this._manifestReferrence && !this._extenalModules[resolvedDep] && pkgName !== appName) ? `${appName}@${resolvedDep}'` : `'${resolvedDep}'`;
+      } else {
+        return codeMatch;
+      }
+      return resolvedDep
         // @Denis
         // ? `${JSON.stringify(resolvedDeps[depName])} /* ${depName} */`
         ? `'${resolvedDeps[depName]}'`
         : codeMatch;
+    }
 
     code = dependencyOffsets.reduceRight((codeBits, offset) => {
       const first = codeBits.shift();
@@ -250,7 +284,9 @@ class Resolver {
         code,
         meta.dependencyOffsets
       );
-      code = defineModuleCode(moduleId, code, name, dev);
+      // @Denis issue #8
+      // code = defineModuleCode(moduleId, code, name, dev);
+      code = defineModuleCode(moduleId, code, name, dev, this._extenalModules, this._manifestReferrence);
     }
 
 
@@ -267,8 +303,13 @@ class Resolver {
     return this._depGraph;
   }
 }
-
-function defineModuleCode(moduleName, code, verboseName = '', dev = true) {
+// @Denis issue #8
+function defineModuleCode(moduleName, code, verboseName = '', dev = true, extenalModules, manifestReferrence) {
+  const pkgName = verboseName.split('/')[0];
+  // 如果有传入manifest.json 并且模块不属于manifest内定义的，并且模块不属于当前App，需要给模块追加命名空间
+  if (manifestReferrence && !extenalModules[verboseName] && pkgName !== appName) {
+    verboseName = `${appName}@${verboseName}`;
+  }
   return [
     `__d(/* ${verboseName} */`,
     'function(global, require, module, exports) {', // module factory

--- a/react-native/packager/react-packager/src/Resolver/index.js
+++ b/react-native/packager/react-packager/src/Resolver/index.js
@@ -241,11 +241,11 @@ class Resolver {
       } else {
         return codeMatch;
       }
-      return resolvedDep
+      // return resolvedDep
         // @Denis
         // ? `${JSON.stringify(resolvedDeps[depName])} /* ${depName} */`
-        ? `'${resolvedDeps[depName]}'`
-        : codeMatch;
+        // ? `'${resolvedDeps[depName]}'`
+        // : codeMatch;
     }
 
     code = dependencyOffsets.reduceRight((codeBits, offset) => {

--- a/tests/.babelrc
+++ b/tests/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": [ "react-native" ],
-  "plugins": [ "add-module-exports" ]
-}

--- a/tests/antd-mobile/lib/button/index.js
+++ b/tests/antd-mobile/lib/button/index.js
@@ -1,7 +1,0 @@
-import React from 'react';
-
-export default class Button extends React.Component {
-  render() {
-    return <span />;
-  }
-}

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,6 +1,14 @@
-import { Button } from './antd-mobile';
-import React from 'react';
+import React, { Component } from 'react';
+import { AppRegistry, Text } from 'react-native';
+import ImagePicker from 'react-native-image-picker';
+import Widget from './widget';
 
-export default function (props) {
-  return <Button {...props}/>;
+class HelloWorldApp extends Component {
+  render() {
+    return (
+      <Text>Hello world!</Text>
+    );
+  }
 }
+
+AppRegistry.registerComponent('HelloWorldApp', () => HelloWorldApp);

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,9 +4,12 @@
   "dependencies": {
     "react": "~15.4.0-rc.4",
     "react-native": "0.39.0",
-    "babel-plugin-antd": "~0.4.0"
+    "react-native-image-picker": "^0.26.2"
   },
   "scripts": {
     "start": "node ../bin/rnpackager start"
+  },
+  "tnpm": {
+    "mode": "yarn"
   }
 }

--- a/tests/widget.js
+++ b/tests/widget.js
@@ -1,0 +1,12 @@
+import React, { Component } from 'react';
+import { Text } from 'react-native';
+
+class Widget extends Component {
+  render() {
+    return (
+      <Text>Widget!</Text>
+    );
+  }
+}
+
+export default Widget;


### PR DESCRIPTION
Resolve #8 
when use `manifest.json` file to bundle, npm modules that not pre-define in manifest will add a namespace before it's module's name. Developers will not be perceived for this modification.